### PR TITLE
Fix satellite_type condition

### DIFF
--- a/roles/redhat_satellite6_storage/tasks/main.yml
+++ b/roles/redhat_satellite6_storage/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Satellite Storage | Verify satellite_type variable
   fail:
     msg: "satellite_type must be one of ['master', 'capsule'] got '{{ satellite_type }}'"
-  when: satellite_type is not in satellite_types
+  when: satellite_type not in satellite_types
 
 - name: Satellite Storage | Install required packages
   package:


### PR DESCRIPTION
Currently it is failing 

~~~
TASK [redhat_satellite6_storage : Satellite Storage | Verify satellite_type variable] ***************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'satellite_type is not in satellite_types' failed. The error was: template error while templating string: no test named 'in'. String: {% if satellite_type is not in satellite_types %} True {% else %} False {% endif %}\n\nThe error appears to be in '/root/ansible-redhat_satellite6/roles/redhat_satellite6_storage/tasks/main.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Satellite Storage | Verify satellite_type variable\n  ^ here\n"}
~~~